### PR TITLE
Add repo url to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": " "
+    "url": "https://github.com/willhey/mcp23017chip"
   },
   "author": "Mike Wilson",
   "license": "MIT"


### PR DESCRIPTION
When the node is next published to npm, the repo url will show in the npm description.